### PR TITLE
Cloudfrontをacmと関連付ける

### DIFF
--- a/react_deploy/acm.tf
+++ b/react_deploy/acm.tf
@@ -2,6 +2,7 @@
 resource "aws_acm_certificate" "cert" {
   domain_name       = local.domain_name
   validation_method = "DNS"
+  provider = aws.virginia
 
   lifecycle {
     create_before_destroy = true
@@ -12,4 +13,5 @@ resource "aws_acm_certificate" "cert" {
 resource "aws_acm_certificate_validation" "cert" {
   certificate_arn = aws_acm_certificate.cert.arn
   validation_record_fqdns = flatten([ values(aws_route53_record.cert)[*].fqdn ])
+  provider = aws.virginia
 }

--- a/react_deploy/cloudfront.tf
+++ b/react_deploy/cloudfront.tf
@@ -1,5 +1,7 @@
 # Cloudfrontを定義
 resource "aws_cloudfront_distribution" "main" {
+  aliases = [ local.domain_name ]
+
   # オリジンの設定
   origin {
     origin_id = aws_s3_bucket.react_app_bucket.id
@@ -38,10 +40,11 @@ resource "aws_cloudfront_distribution" "main" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
-    # acm_certificate_arn = aws_acm_certificate.cert.arn
-    # ssl_support_method = "sni-only"
-    # minimum_protocol_version = "TLSv1"
+    # cloudfront_default_certificate = true
+    acm_certificate_arn = aws_acm_certificate.cert.arn
+    ssl_support_method = "sni-only"
+    minimum_protocol_version = "TLSv1"
+    # minimum_protocol_version = "TLSv1.2_2021"
   }
 }
 

--- a/react_deploy/main.tf
+++ b/react_deploy/main.tf
@@ -8,7 +8,3 @@ terraform {
 
   required_version = ">= 1.2.0"
 }
-
-provider "aws" {
-  region  = "ap-northeast-1"
-}

--- a/react_deploy/provider.tf
+++ b/react_deploy/provider.tf
@@ -1,0 +1,12 @@
+# デフォルトではこちらの値が使われる
+provider "aws" {
+  region  = "ap-northeast-1"
+}
+
+# こちらを指定するには
+# provider = aws.virginia
+# と記述する
+provider "aws" {
+  alias  = "virginia"
+  region = "us-east-1"
+}


### PR DESCRIPTION
特定のドメインからCloudfrontへHTTPSでアクセスできるように修正

https://hisuiblog.com/error-aws-terraform-cloudfront-acm-cant-access/
このブログの対応内容を反映