### PR TITLE
add s3_response_404_error

### DIFF
--- a/nextjs_deploy/s3.tf
+++ b/nextjs_deploy/s3.tf
@@ -39,8 +39,14 @@ data "aws_iam_policy_document" "next_app_bucket" {
       type = "Service"
       identifiers = [ "cloudfront.amazonaws.com" ]
     }
-    actions = [ "s3:GetObject" ]
-    resources = [ "${aws_s3_bucket.next_app_bucket.arn}/*" ]
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket"
+    ]
+    resources = [
+      "${aws_s3_bucket.next_app_bucket.arn}",
+      "${aws_s3_bucket.next_app_bucket.arn}/*"
+    ]
     condition {
       test = "StringEquals"
       variable = "aws:SourceArn"

--- a/react_deploy/s3.tf
+++ b/react_deploy/s3.tf
@@ -39,8 +39,14 @@ data "aws_iam_policy_document" "react_app_bucket" {
       type = "Service"
       identifiers = [ "cloudfront.amazonaws.com" ]
     }
-    actions = [ "s3:GetObject" ]
-    resources = [ "${aws_s3_bucket.react_app_bucket.arn}/*" ]
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket"
+    ]
+    resources = [
+      "${aws_s3_bucket.react_app_bucket.arn}",
+      "${aws_s3_bucket.react_app_bucket.arn}/*"
+    ]
     condition {
       test = "StringEquals"
       variable = "aws:SourceArn"


### PR DESCRIPTION
# 概要
S3にオブジェクトがないものへアクセスした場合に403ではなく、404を返すようにする

# 内容
https://hisuiblog.com/aws-cloudfront-s3-response-404-error/